### PR TITLE
Switch to query-string-es5 to fix build

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8888,10 +8888,10 @@
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
       "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
     },
-    "query-string": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.1.0.tgz",
-      "integrity": "sha512-pNB/Gr8SA8ff8KpUFM36o/WFAlthgaThka5bV19AD9PNTH20Pwq5Zxodif2YyHwrctp6SkL4GqlOot0qR/wGaw==",
+    "query-string-es5": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/query-string-es5/-/query-string-es5-6.1.4.tgz",
+      "integrity": "sha512-pMdQETPqMQO+OUd2t3hUxBV8REa6w+iyD+o87M1qc1Vj3jBkQIIw3aZc+6rxlRTDxZ5ac+w0rGE/p4JIt2Xupg==",
       "requires": {
         "decode-uri-component": "^0.2.0",
         "strict-uri-encode": "^2.0.0"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "lodash": "^4.17.10",
     "moment": "^2.22.1",
     "prop-types": "^15.6.1",
-    "query-string": "^6.1.0",
+    "query-string-es5": "^6.1.0",
     "rc-slider": "^8.6.1",
     "react": "^16.3.2",
     "react-dom": "^16.3.2",

--- a/src/components/reader/WebtoonReader.js
+++ b/src/components/reader/WebtoonReader.js
@@ -11,7 +11,7 @@ import { Server, Client } from 'api';
 import { withRouter } from 'react-router-dom';
 import Link from 'components/Link';
 import Waypoint from 'react-waypoint';
-import queryString from 'query-string';
+import queryString from 'query-string-es5';
 
 // Waypoints that wrap around components require special code
 // However, it automatically works with normal elements like <div>


### PR DESCRIPTION
`npm run build` refuses to run if the `query-string` package is installed since it's written in ES6.

Instead, we use an ES5 port of the original `query-string` package to workaround this.