### PR TITLE
Fix invalid dates from displaying in chapter list items

### DIFF
--- a/src/components/mangaInfo/ChapterListItem.js
+++ b/src/components/mangaInfo/ChapterListItem.js
@@ -1,53 +1,57 @@
 // @flow
-import React, { useContext } from 'react';
-import ListItem from '@material-ui/core/ListItem';
-import { withStyles } from '@material-ui/core/styles';
-import Typography from '@material-ui/core/Typography';
-import classNames from 'classnames';
-import Link from 'components/Link';
-import type { ChapterType, MangaType } from 'types';
-import { chapterNumPrettyPrint } from 'components/utils';
-import ChapterMenu from 'components/mangaInfo/ChapterMenu';
-import UrlPrefixContext from 'components/UrlPrefixContext';
-import { Client } from 'api';
-import dateFnsFormat from 'date-fns/format';
+import React, { useContext } from "react";
+import ListItem from "@material-ui/core/ListItem";
+import { withStyles } from "@material-ui/core/styles";
+import Typography from "@material-ui/core/Typography";
+import classNames from "classnames";
+import Link from "components/Link";
+import type { ChapterType, MangaType } from "types";
+import { chapterNumPrettyPrint } from "components/utils";
+import ChapterMenu from "components/mangaInfo/ChapterMenu";
+import UrlPrefixContext from "components/UrlPrefixContext";
+import { Client } from "api";
+import dateFnsFormat from "date-fns/format";
 
 const styles = () => ({
   read: {
-    color: '#AAA',
+    color: "#AAA"
   },
   listItem: {
-    paddingRight: 8, // decrease padding (default 24)
+    paddingRight: 8 // decrease padding (default 24)
   },
   chapterInfo: {
     flex: 1,
-    marginRight: 8,
+    marginRight: 8
   },
   extraInfo: {
-    display: 'flex',
-    justifyContent: 'center',
-    alignItems: 'flex-end',
+    display: "flex",
+    justifyContent: "center",
+    alignItems: "flex-end"
   },
   date: { flex: 1 },
-  lastReadPage: { color: 'rgba(0, 0, 0, 0.87)' },
+  lastReadPage: { color: "rgba(0, 0, 0, 0.87)" }
 });
 
 type Props = {
   classes: Object,
   mangaInfo: MangaType,
   chapter: ChapterType,
-  toggleRead: Function,
+  toggleRead: Function
 };
 
 const ChapterListItem = ({
-  classes, mangaInfo, chapter, toggleRead,
+  classes,
+  mangaInfo,
+  chapter,
+  toggleRead
 }: Props) => {
   const urlPrefix = useContext(UrlPrefixContext);
 
-  const dimIfRead: Function = (read: boolean): ?String => (read ? classes.read : null);
+  const dimIfRead: Function = (read: boolean): ?String =>
+    read ? classes.read : null;
   const goToPage: number = chapter.read ? 0 : chapter.last_page_read;
   const chapterName: string =
-    mangaInfo.flags.DISPLAY_MODE === 'NAME'
+    mangaInfo.flags.DISPLAY_MODE === "NAME"
       ? chapter.name
       : `Chapter ${chapterNumPrettyPrint(chapter.chapter_number)}`;
 
@@ -69,13 +73,10 @@ const ChapterListItem = ({
             variant="caption"
             className={classNames(classes.date, dimIfRead(chapter.read))}
           >
-            {dateFnsFormat(chapter.date, 'MM/DD/YYYY')}
+            {chapter.date ? dateFnsFormat(chapter.date, "MM/DD/YYYY") : ""}
           </Typography>
 
-          <Typography
-            variant="caption"
-            className={classes.lastReadPage}
-          >
+          <Typography variant="caption" className={classes.lastReadPage}>
             {chapterText(chapter.read, chapter.last_page_read)}
           </Typography>
         </div>
@@ -89,7 +90,7 @@ const ChapterListItem = ({
 // Helper Functions
 /* eslint-disable camelcase */
 function chapterText(read: boolean, last_page_read: number) {
-  let text: string = '';
+  let text: string = "";
   if (!read && last_page_read > 0) {
     text = `Page ${last_page_read + 1}`;
   }


### PR DESCRIPTION
The date property is a unix timestamp string. In this issue https://github.com/Ligerx/TachiWeb-React/issues/44, the date was 0, but it still parsed into a valid date. There doesn't seem to be a straightforward way to check if something is a valid unix timestamp, so I'm just checking if it's falsy.

Visually, it's mostly fine.
![image](https://user-images.githubusercontent.com/6577974/57991765-c3fe0180-7a65-11e9-9040-ee98c38843b8.png)
![image](https://user-images.githubusercontent.com/6577974/57991771-c7918880-7a65-11e9-88b3-99518f4847bf.png)

Note, this file has also been formatted with prettier/eslint

closes https://github.com/Ligerx/TachiWeb-React/issues/44