### PR TITLE
Extensions are now sorted

### DIFF
--- a/src/components/extensions/ExtensionList.js
+++ b/src/components/extensions/ExtensionList.js
@@ -1,0 +1,60 @@
+// @flow
+import * as React from "react";
+import type { ExtensionType } from "types";
+import Paper from "@material-ui/core/Paper";
+import Grid from "@material-ui/core/Grid";
+import List from "@material-ui/core/List";
+import ExtensionListItem from "components/extensions/ExtensionListItem";
+import Typography from "@material-ui/core/Typography";
+import ExtensionButton from "components/extensions/ExtensionButton";
+
+type Props = {
+  title: string,
+  extensions: Array<ExtensionType>,
+  onUpdateClick: Function,
+  onInstallClick: Function,
+  onUninstallClick: Function
+};
+
+const ExtensionList = ({
+  title,
+  extensions,
+  onUpdateClick,
+  onInstallClick,
+  onUninstallClick
+}: Props) => {
+  if (!extensions.length) return null;
+
+  return (
+    <Grid item xs={12}>
+      <Typography variant="headline" gutterBottom>
+        {title} ({extensions.length})
+      </Typography>
+      <Paper>
+        <List>
+          {extensions.map((extension, index, array) => {
+            const divider = index !== array.length - 1;
+            return (
+              <ExtensionListItem
+                key={extension.pkg_name}
+                extension={extension}
+                divider={divider}
+              >
+                <ExtensionButton
+                  status={extension.status}
+                  has_update={extension.has_update}
+                  name={extension.name}
+                  onUpdateClick={() => onUpdateClick(extension.pkg_name)}
+                  onInstallClick={() => onInstallClick(extension.pkg_name)}
+                  onUninstallClick={() => onUninstallClick(extension.pkg_name)}
+                />
+              </ExtensionListItem>
+            );
+          })}
+        </List>
+      </Paper>
+    </Grid>
+  );
+};
+
+export default ExtensionList;

--- a/src/components/extensions/ExtensionListItem.js
+++ b/src/components/extensions/ExtensionListItem.js
@@ -18,14 +18,20 @@ const styles = () => ({
 type Props = {
   classes: Object,
   extension: ExtensionType,
+  divider: boolean,
   children: React.Node
 };
 
-const ExtensionListItem = ({ classes, extension, children }: Props) => {
+const ExtensionListItem = ({
+  classes,
+  extension,
+  divider,
+  children
+}: Props) => {
   const { pkg_name, name, lang, version_name } = extension;
 
   return (
-    <ListItem divider>
+    <ListItem divider={divider}>
       <Avatar className={classes.avatar} src={Server.extensionIcon(pkg_name)} />
       <ListItemText
         primary={name}

--- a/src/pages/Extensions.js
+++ b/src/pages/Extensions.js
@@ -10,6 +10,7 @@ import Toolbar from "@material-ui/core/Toolbar";
 import MenuDrawer from "components/MenuDrawer";
 import RefreshButton from "components/RefreshButton";
 import ExtensionList from "components/extensions/ExtensionList";
+import type { ExtensionType } from "types";
 
 // Currently, the buttons that appear do not completely match Tachiyomi's buttons.
 // Partially because I'm missing extension preferences,
@@ -27,13 +28,26 @@ const Extensions = ({
     fetchExtensions();
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
-  const installedExtensions = extensions.filter(
-    extension => extension.status === "INSTALLED"
-  );
+  function extensionSort(a: ExtensionType, b: ExtensionType) {
+    // First sort alphabetically by language
+    // Not using the pretty print / native name, but it gets the job done
+    if (a.lang > b.lang) return 1;
+    if (a.lang < b.lang) return -1;
 
-  const notInstalledExtensions = extensions.filter(
-    extension => extension.status !== "INSTALLED"
-  );
+    // Then sort alphabetically by source name
+    if (a.name > b.name) return 1;
+    if (a.name < b.name) return -1;
+
+    return 0;
+  }
+
+  const installedExtensions = extensions
+    .filter(extension => extension.status === "INSTALLED")
+    .sort(extensionSort);
+
+  const notInstalledExtensions = extensions
+    .filter(extension => extension.status !== "INSTALLED")
+    .sort(extensionSort);
 
   return (
     <React.Fragment>

--- a/src/pages/Extensions.js
+++ b/src/pages/Extensions.js
@@ -4,26 +4,16 @@ import FullScreenLoading from "components/loading/FullScreenLoading";
 import type { ExtensionsContainerProps } from "containers/ExtensionsContainer";
 import { Helmet } from "react-helmet";
 import ResponsiveGrid from "components/ResponsiveGrid";
-import Paper from "@material-ui/core/Paper";
-import Grid from "@material-ui/core/Grid";
-import List from "@material-ui/core/List";
-import { withStyles } from "@material-ui/core/styles";
-import ExtensionListItem from "components/extensions/ExtensionListItem";
 import Typography from "@material-ui/core/Typography";
-import ExtensionButton from "components/extensions/ExtensionButton";
 import AppBar from "@material-ui/core/AppBar";
 import Toolbar from "@material-ui/core/Toolbar";
 import MenuDrawer from "components/MenuDrawer";
 import RefreshButton from "components/RefreshButton";
+import ExtensionList from "components/extensions/ExtensionList";
 
 // Currently, the buttons that appear do not completely match Tachiyomi's buttons.
 // Partially because I'm missing extension preferences,
 // but also because I don't think it's worth the effort to implement.
-
-const styles = () => ({
-  avatar: { borderRadius: 0 },
-  secondary: { right: 24 }
-});
 
 const Extensions = ({
   extensions,
@@ -32,7 +22,7 @@ const Extensions = ({
   installExtension,
   uninstallExtension,
   reloadExtensions
-}: ExtensionsContainerProps & { classes: Object }) => {
+}: ExtensionsContainerProps) => {
   useEffect(() => {
     fetchExtensions();
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
@@ -62,68 +52,21 @@ const Extensions = ({
       </AppBar>
 
       <ResponsiveGrid maxWidth="xs">
-        {installedExtensions.length > 0 && (
-          <Grid item xs={12}>
-            <Typography variant="headline" gutterBottom>
-              Installed ({installedExtensions.length})
-            </Typography>
-            <Paper>
-              <List>
-                {installedExtensions.map(extension => (
-                  <ExtensionListItem
-                    key={extension.pkg_name}
-                    extension={extension}
-                  >
-                    <ExtensionButton
-                      status={extension.status}
-                      has_update={extension.has_update}
-                      name={extension.name}
-                      onUpdateClick={() => installExtension(extension.pkg_name)}
-                      onInstallClick={() =>
-                        installExtension(extension.pkg_name)
-                      }
-                      onUninstallClick={() =>
-                        uninstallExtension(extension.pkg_name)
-                      }
-                    />
-                  </ExtensionListItem>
-                ))}
-              </List>
-            </Paper>
-          </Grid>
-        )}
+        <ExtensionList
+          title="Installed"
+          extensions={installedExtensions}
+          onUpdateClick={installExtension}
+          onInstallClick={installExtension}
+          onUninstallClick={uninstallExtension}
+        />
 
-        {notInstalledExtensions.length > 0 && (
-          <Grid item xs={12}>
-            <Typography variant="headline" gutterBottom>
-              Available ({notInstalledExtensions.length})
-            </Typography>
-
-            <Paper>
-              <List>
-                {notInstalledExtensions.map(extension => (
-                  <ExtensionListItem
-                    key={extension.pkg_name}
-                    extension={extension}
-                  >
-                    <ExtensionButton
-                      status={extension.status}
-                      has_update={extension.has_update}
-                      name={extension.name}
-                      onUpdateClick={() => installExtension(extension.pkg_name)}
-                      onInstallClick={() =>
-                        installExtension(extension.pkg_name)
-                      }
-                      onUninstallClick={() =>
-                        uninstallExtension(extension.pkg_name)
-                      }
-                    />
-                  </ExtensionListItem>
-                ))}
-              </List>
-            </Paper>
-          </Grid>
-        )}
+        <ExtensionList
+          title="Available"
+          extensions={notInstalledExtensions}
+          onUpdateClick={installExtension}
+          onInstallClick={installExtension}
+          onUninstallClick={uninstallExtension}
+        />
       </ResponsiveGrid>
 
       {extensionsIsLoading && <FullScreenLoading />}
@@ -131,4 +74,4 @@ const Extensions = ({
   );
 };
 
-export default withStyles(styles)(Extensions);
+export default Extensions;


### PR DESCRIPTION
closes #38 

Implement extension sort just to be sure that they stay in order after any sort of update.
Also extract an `<ExtensionList />` component and fix the trailing divider line.