### PR TITLE
Manually merge pr 39

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1372,9 +1372,9 @@
       }
     },
     "@tachiweb/api-client": {
-      "version": "1.0.0-alpha.72",
-      "resolved": "https://registry.npmjs.org/@tachiweb/api-client/-/api-client-1.0.0-alpha.72.tgz",
-      "integrity": "sha512-piS1nbRK+bs9o5+XyrE645aZCWea6aNYXqzk0dyzgsYDwG0X47maME5kNG11ofrMBSKtrRqbNKW/PXI7b9zm1g==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@tachiweb/api-client/-/api-client-3.2.0.tgz",
+      "integrity": "sha512-5qXUo2TQ3Ve9qMFvj6jH5Adysf1u5906leBhNLp+x2b4HYtpFTlAWMPvWGIMpzTeNTC1YTTPS1dHrDPxdJZ1wA==",
       "requires": {
         "portable-fetch": "^3.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "@material-ui/core": "^4.0.1",
     "@material-ui/styles": "^4.0.1",
-    "@tachiweb/api-client": "1.0.0-alpha.72",
+    "@tachiweb/api-client": "3.2.0",
     "classnames": "^2.2.5",
     "date-fns": "^1.29.0",
     "iso-639-1": "^2.0.3",

--- a/src/api.js
+++ b/src/api.js
@@ -29,7 +29,7 @@ export const Server = {
   },
 
   cover(mangaId) {
-    return `/api/cover/${mangaId}`;
+    return `/api/v3/manga/${mangaId}/cover`;
   },
 
   pageCount(mangaId, chapterId) {

--- a/src/components/Catalogue/CatalogueHeader.js
+++ b/src/components/Catalogue/CatalogueHeader.js
@@ -1,5 +1,6 @@
 // @flow
 import React, { useRef } from "react";
+import isEmpty from "lodash/isEmpty";
 import { useSelector, useDispatch } from "react-redux";
 import debounce from "lodash/debounce";
 import AppBar from "@material-ui/core/AppBar";
@@ -54,8 +55,7 @@ const CatalogueHeader = () => {
   const handleSourceChange = (event: SyntheticEvent<HTMLLIElement>) => {
     // NOTE: Using LIElement because that's how my HTML is structured.
     //       Doubt it'll cause problems, but change this or the actual component if needed.
-    const newSourceIndex = parseInt(event.currentTarget.dataset.value, 10);
-    const newSourceId = sources[newSourceIndex].id;
+    const newSourceId = event.currentTarget.dataset.value;
 
     dispatch(resetCatalogue());
     dispatch(changeSourceId(newSourceId));
@@ -63,8 +63,7 @@ const CatalogueHeader = () => {
     dispatch(fetchCatalogue());
   };
 
-  const sourcesExist = sources && sources.length > 0 && sourceId != null;
-  const sourceIndex = sources.findIndex(source => source.id === sourceId);
+  const sourcesExist = sources && !isEmpty(sources) && sourceId != null;
 
   return (
     <AppBar color="default" position="static" style={{ marginBottom: 20 }}>
@@ -74,13 +73,18 @@ const CatalogueHeader = () => {
         {sourcesExist && (
           <>
             <Select
-              value={sourceIndex}
+              value={sourceId}
               onChange={handleSourceChange}
               classes={{ select: classes.catalogueSelect }}
             >
-              {sources.map((source, index) => (
-                <MenuItem value={index} key={source.id}>
-                  {source.name}
+              {Object.keys(sources).map(itemSourceId => (
+                <MenuItem
+                  value={sources[itemSourceId].id}
+                  key={sources[itemSourceId].id}
+                >
+                  {(sources[itemSourceId].lang != null
+                    ? `(${sources[itemSourceId].lang.toUpperCase()}) `
+                    : "") + sources[itemSourceId].name}
                 </MenuItem>
               ))}
             </Select>

--- a/src/components/Catalogue/CatalogueMangaCard.js
+++ b/src/components/Catalogue/CatalogueMangaCard.js
@@ -4,7 +4,7 @@ import Grid from "@material-ui/core/Grid";
 import { withStyles } from "@material-ui/core/styles";
 import ButtonBase from "@material-ui/core/ButtonBase";
 import MangaCard from "components/MangaCard";
-import type { MangaType } from "types";
+import type { Manga } from "@tachiweb/api-client";
 import { Server, Client } from "api";
 import Link from "components/Link";
 
@@ -22,7 +22,7 @@ const styles = {
 
 type Props = {
   classes: Object,
-  manga: MangaType
+  manga: Manga
 };
 
 const CatalogueMangaCard = ({ classes, manga }: Props) => (

--- a/src/components/Catalogue/index.js
+++ b/src/components/Catalogue/index.js
@@ -3,6 +3,7 @@ import React, { useEffect } from "react";
 import { useSelector, useDispatch } from "react-redux";
 import Waypoint from "react-waypoint";
 import { Helmet } from "react-helmet";
+import isEmpty from "lodash/isEmpty";
 import { makeStyles } from "@material-ui/styles";
 import Typography from "@material-ui/core/Typography";
 import MangaGrid from "components/MangaGrid";
@@ -57,7 +58,7 @@ const Catalogue = () => {
 
   useEffect(() => {
     // Only reload on component mount if it's missing data, otherwise show cached data
-    if (sources.length === 0 || sourceId == null) {
+    if (isEmpty(sources) || sourceId == null) {
       dispatch(fetchSources()).then(() => {
         dispatch(fetchCatalogue());
         dispatch(fetchFilters());

--- a/src/components/Catalogue/index.js
+++ b/src/components/Catalogue/index.js
@@ -27,10 +27,6 @@ import {
 import { fetchFilters } from "redux-ducks/filters/actionCreators";
 
 // TODO: keep previous scroll position when going back from MangaInfo -> Catalogue
-
-// FIXME: If you type something into the search bar,
-//        then delete everything, searching breaks (no results)
-
 // TODO: If you update search, then change it back to it's original value, don't search again?
 
 const useStyles = makeStyles({

--- a/src/components/Extensions/ExtensionList.js
+++ b/src/components/Extensions/ExtensionList.js
@@ -24,8 +24,8 @@ const ExtensionList = ({ title, extensions }: Props) => {
   const handleInstallExtension = packageName =>
     dispatch(installExtension(packageName));
 
-  const handleUninstallExtension = packageName =>
-    dispatch(uninstallExtension(packageName));
+  const handleUninstallExtension = extension =>
+    dispatch(uninstallExtension(extension));
 
   if (!extensions.length) return null;
 
@@ -54,9 +54,7 @@ const ExtensionList = ({ title, extensions }: Props) => {
                   onInstallClick={() =>
                     handleInstallExtension(extension.pkg_name)
                   }
-                  onUninstallClick={() =>
-                    handleUninstallExtension(extension.pkg_name)
-                  }
+                  onUninstallClick={() => handleUninstallExtension(extension)}
                 />
               </ExtensionListItem>
             );

--- a/src/components/Library/LibraryMangaCard.js
+++ b/src/components/Library/LibraryMangaCard.js
@@ -7,7 +7,7 @@ import ButtonBase from "@material-ui/core/ButtonBase";
 import MangaCard from "components/MangaCard";
 import Link from "components/Link";
 import { Server, Client } from "api";
-import type { MangaType } from "types";
+import type { Manga } from "@tachiweb/api-client";
 
 // TODO: Currently passing in the entire unread object, not just the corresponding number
 //       ^ Would have to rework the component tree a big to make that happen.
@@ -26,7 +26,7 @@ const styles = {
 
 type Props = {
   classes: Object,
-  manga: MangaType,
+  manga: Manga,
   unread: { [mangaId: number]: number }
 };
 

--- a/src/components/Library/LibrarySort.js
+++ b/src/components/Library/LibrarySort.js
@@ -11,7 +11,8 @@ import { withStyles } from "@material-ui/core/styles";
 
 const sorts = [
   { flagState: "ALPHA", description: "Alphabetically" },
-  // "LAST_READ" and "LAST_UPDATED" not yet implemented
+  { flagState: "LAST_READ", description: "Last read" },
+  { flagState: "LAST_UPDATED", description: "Last updated" },
   { flagState: "UNREAD", description: "Unread" },
   { flagState: "TOTAL", description: "Total chapters" },
   { flagState: "SOURCE", description: "Source" }

--- a/src/components/Library/index.js
+++ b/src/components/Library/index.js
@@ -17,6 +17,7 @@ import LibraryHeader from "components/Library/LibraryHeader";
 import MangaGrid from "components/MangaGrid";
 import LibraryMangaCard from "components/Library/LibraryMangaCard";
 import FullScreenLoading from "components/Loading/FullScreenLoading";
+import { fetchSources } from "redux-ducks/sources/actionCreators";
 
 // TODO: no feedback of success/errors after clicking the library update button
 
@@ -36,9 +37,9 @@ const Library = () => {
   const dispatch = useDispatch();
 
   useEffect(() => {
-    dispatch(fetchLibrary());
-    dispatch(fetchUnread());
+    dispatch(fetchLibrary()).then(() => dispatch(fetchUnread()));
     dispatch(fetchLibraryFlags());
+    dispatch(fetchSources());
   }, [dispatch]);
 
   return (

--- a/src/components/MangaGrid.js
+++ b/src/components/MangaGrid.js
@@ -1,10 +1,10 @@
 // @flow
 import * as React from "react";
 import ResponsiveGrid from "components/ResponsiveGrid";
-import type { MangaType } from "types";
+import type { Manga } from "@tachiweb/api-client";
 
 type Props = {
-  mangaLibrary: Array<MangaType>,
+  mangaLibrary: Array<Manga>,
   cardComponent: React.Element<any> // single node only
 };
 

--- a/src/components/MangaInfo/ChapterListItem.js
+++ b/src/components/MangaInfo/ChapterListItem.js
@@ -4,7 +4,8 @@ import ListItem from "@material-ui/core/ListItem";
 import Typography from "@material-ui/core/Typography";
 import classNames from "classnames";
 import Link from "components/Link";
-import type { ChapterType, MangaType } from "types";
+import type { ChapterType } from "types";
+import type { Manga } from "@tachiweb/api-client";
 import { chapterNumPrettyPrint } from "components/utils";
 import ChapterMenu from "components/MangaInfo/ChapterMenu";
 import UrlPrefixContext from "components/UrlPrefixContext";
@@ -15,7 +16,7 @@ import { toggleRead } from "redux-ducks/chapters/actionCreators";
 import { makeStyles } from "@material-ui/styles";
 
 type Props = {
-  mangaInfo: MangaType,
+  mangaInfo: Manga,
   chapter: ChapterType
 }; // other props will be passed to the root ListItem
 
@@ -53,7 +54,7 @@ const ChapterListItem = memo(({ mangaInfo, chapter, ...otherProps }: Props) => {
     read ? classes.read : null;
   const goToPage: number = chapter.read ? 0 : chapter.last_page_read;
   const chapterName: string =
-    mangaInfo.flags.DISPLAY_MODE === "NAME"
+    mangaInfo.flags.displayMode === "NAME"
       ? chapter.name
       : `Chapter ${chapterNumPrettyPrint(chapter.chapter_number)}`;
 

--- a/src/components/MangaInfo/MangaInfoChapterList.js
+++ b/src/components/MangaInfo/MangaInfoChapterList.js
@@ -4,7 +4,8 @@ import Grid from "@material-ui/core/Grid";
 import ResponsiveGrid from "components/ResponsiveGrid";
 import Paper from "@material-ui/core/Paper";
 import ChapterListItem from "components/MangaInfo/ChapterListItem";
-import type { ChapterType, MangaType } from "types";
+import type { ChapterType } from "types";
+import type { Manga } from "@tachiweb/api-client";
 import { makeStyles } from "@material-ui/styles";
 import { FixedSizeList, areEqual } from "react-window";
 import AutoSizer from "react-virtualized-auto-sizer";
@@ -22,7 +23,7 @@ import AutoSizer from "react-virtualized-auto-sizer";
 // https://react-window.now.sh/#/examples/list/memoized-list-items
 
 type Props = {
-  mangaInfo: MangaType,
+  mangaInfo: Manga,
   chapters: Array<ChapterType>
 };
 

--- a/src/components/MangaInfo/MangaInfoDetails.js
+++ b/src/components/MangaInfo/MangaInfoDetails.js
@@ -6,10 +6,11 @@ import MangaCard from "components/MangaCard";
 import Grid from "@material-ui/core/Grid";
 import BackgroundImage from "components/MangaInfo/BackgroundImage";
 import { withStyles } from "@material-ui/core/styles";
-import type { MangaType } from "types";
+import type { Manga, Source } from "@tachiweb/api-client";
 import classNames from "classnames";
 import { Server } from "api";
 import upperFirst from "lodash/upperFirst";
+import capitalize from "lodash/capitalize";
 import FavoriteFab from "components/FavoriteFab";
 
 // TODO: increase top/bottom padding for description so it doesn't touch the FAB
@@ -28,11 +29,17 @@ const styles = () => ({
 
 type Props = {
   classes: Object,
-  mangaInfo: MangaType,
-  numChapters: number
+  mangaInfo: Manga,
+  numChapters: number,
+  source: ?Source
 };
 
-const MangaInfoDetails = ({ classes, mangaInfo, numChapters }: Props) => {
+const MangaInfoDetails = ({
+  classes,
+  source,
+  mangaInfo,
+  numChapters
+}: Props) => {
   const coverUrl: string = Server.cover(mangaInfo.id);
 
   return (
@@ -50,6 +57,13 @@ const MangaInfoDetails = ({ classes, mangaInfo, numChapters }: Props) => {
             </Typography>
             <DetailComponent fieldName="Chapters" value={numChapters} />
             {detailsElements(mangaInfo)}
+            <DetailComponent
+              fieldName="Status"
+              value={capitalize(mangaInfo.status)}
+            />
+            {source != null && (
+              <DetailComponent fieldName="Source" value={source.name} />
+            )}
           </Grid>
 
           <FavoriteFab mangaId={mangaInfo.id} />
@@ -71,8 +85,8 @@ MangaInfoDetails.defaultProps = {
 };
 
 // Helper functions
-function detailsElements(mangaInfo: MangaType): React.Node {
-  const fieldNames = ["status", "source", "author", "genres", "categories"];
+function detailsElements(mangaInfo: Manga): React.Node {
+  const fieldNames = ["author", "artist", "genre"];
 
   return fieldNames.map(fieldName => {
     const value = mangaInfo[fieldName];

--- a/src/components/MangaInfo/MangaInfoFilter.js
+++ b/src/components/MangaInfo/MangaInfoFilter.js
@@ -7,7 +7,7 @@ import Menu from "@material-ui/core/Menu";
 import MenuItem from "@material-ui/core/MenuItem";
 import Checkbox from "@material-ui/core/Checkbox";
 import FormControlLabel from "@material-ui/core/FormControlLabel";
-import type { MangaInfoFlagsType } from "types";
+import type { MangaFlags } from "@tachiweb/api-client";
 
 // A disabled MenuItem will not fire it's onClick event.
 
@@ -17,7 +17,7 @@ import type { MangaInfoFlagsType } from "types";
 // effectively undoing the click. I'm using event.preventDefault() to avoid this.
 
 type Props = {
-  flags: MangaInfoFlagsType,
+  flags: MangaFlags,
   onReadFilterChange: Function,
   onDownloadedFilterChange: Function
 };
@@ -36,8 +36,8 @@ class MangaInfoFilter extends Component<Props, State> {
   handleRemoveFilters = () => {
     const { onReadFilterChange, onDownloadedFilterChange } = this.props;
 
-    onReadFilterChange("ALL");
-    onDownloadedFilterChange("ALL");
+    onReadFilterChange("SHOW_ALL");
+    onDownloadedFilterChange("SHOW_ALL");
 
     this.setState({ anchorEl: null }); // Also close the menu
   };
@@ -49,14 +49,16 @@ class MangaInfoFilter extends Component<Props, State> {
   handleReadClick = (e: SyntheticEvent<>) => {
     e.preventDefault();
     const { flags, onReadFilterChange } = this.props;
-    const newReadFlag = flags.READ_FILTER === "ALL" ? "READ" : "ALL";
+    const newReadFlag =
+      flags.readFilter === "SHOW_ALL" ? "SHOW_READ" : "SHOW_ALL";
     onReadFilterChange(newReadFlag);
   };
 
   handleUnreadClick = (e: SyntheticEvent<>) => {
     e.preventDefault();
     const { flags, onReadFilterChange } = this.props;
-    const newReadFlag = flags.READ_FILTER === "ALL" ? "UNREAD" : "ALL";
+    const newReadFlag =
+      flags.readFilter === "SHOW_ALL" ? "SHOW_UNREAD" : "SHOW_ALL";
     onReadFilterChange(newReadFlag);
   };
 
@@ -64,7 +66,7 @@ class MangaInfoFilter extends Component<Props, State> {
     e.preventDefault();
     const { flags, onDownloadedFilterChange } = this.props;
     const newDownloadedFlag =
-      flags.DOWNLOADED_FILTER === "ALL" ? "DOWNLOADED" : "ALL";
+      flags.downloadedFilter === "SHOW_ALL" ? "SHOW_DOWNLOADED" : "SHOW_ALL";
     onDownloadedFilterChange(newDownloadedFlag);
   };
 
@@ -72,8 +74,8 @@ class MangaInfoFilter extends Component<Props, State> {
     const { flags } = this.props;
     const { anchorEl } = this.state;
 
-    const readIsDisabled = flags.READ_FILTER === "UNREAD";
-    const unreadIsDisabled = flags.READ_FILTER === "READ";
+    const readIsDisabled = flags.readFilter === "SHOW_UNREAD";
+    const unreadIsDisabled = flags.readFilter === "SHOW_READ";
 
     return (
       <>
@@ -94,7 +96,7 @@ class MangaInfoFilter extends Component<Props, State> {
           <MenuItem onClick={this.handleReadClick} disabled={readIsDisabled}>
             <FormControlLabel
               label="Read"
-              control={<Checkbox checked={flags.READ_FILTER === "READ"} />}
+              control={<Checkbox checked={flags.readFilter === "SHOW_READ"} />}
             />
           </MenuItem>
 
@@ -104,7 +106,9 @@ class MangaInfoFilter extends Component<Props, State> {
           >
             <FormControlLabel
               label="Unread"
-              control={<Checkbox checked={flags.READ_FILTER === "UNREAD"} />}
+              control={
+                <Checkbox checked={flags.readFilter === "SHOW_UNREAD"} />
+              }
             />
           </MenuItem>
 
@@ -112,7 +116,9 @@ class MangaInfoFilter extends Component<Props, State> {
             <FormControlLabel
               label="Downloaded"
               control={
-                <Checkbox checked={flags.DOWNLOADED_FILTER === "DOWNLOADED"} />
+                <Checkbox
+                  checked={flags.downloadedFilter === "SHOW_DOWNLOADED"}
+                />
               }
             />
           </MenuItem>

--- a/src/components/MangaInfo/MangaInfoHeader.js
+++ b/src/components/MangaInfo/MangaInfoHeader.js
@@ -7,7 +7,7 @@ import Icon from "@material-ui/core/Icon";
 import IconButton from "@material-ui/core/IconButton";
 import RefreshButton from "components/RefreshButton";
 import MangaInfoTabs from "components/MangaInfo/MangaInfoTabs";
-import type { MangaType } from "types";
+import type { Manga } from "@tachiweb/api-client";
 import BackButton from "components/BackButton";
 import MangaInfoMore from "components/MangaInfo/MangaInfoMore";
 import Tooltip from "@material-ui/core/Tooltip";
@@ -22,7 +22,7 @@ import { updateChapters } from "redux-ducks/chapters/actionCreators";
 // NOTE: empty href in IconButton will not render <a>
 
 type Props = {
-  mangaInfo: MangaType,
+  mangaInfo: Manga,
   tabValue: number,
   handleChangeTab: Function,
   onBackClick: string | Function
@@ -84,28 +84,25 @@ const MangaInfoHeader = ({
 };
 
 function handleSortClick(handleSetFlag, flags) {
-  return () => {
-    const newState =
-      flags.SORT_DIRECTION === "DESCENDING" ? "ASCENDING" : "DESCENDING";
-    handleSetFlag("SORT_DIRECTION", newState);
-  };
+  return () =>
+    setFlag("sortDirection", flags.sortDirection === "DESC" ? "ASC" : "DESC");
 }
 
 function handleDisplayModeChange(handleSetFlag) {
-  return newDisplayMode => handleSetFlag("DISPLAY_MODE", newDisplayMode);
+  return newDisplayMode => handleSetFlag("displayMode", newDisplayMode);
 }
 
 function handleSortTypeChange(handleSetFlag) {
-  return newSortType => handleSetFlag("SORT_TYPE", newSortType);
+  return newSortType => handleSetFlag("sortType", newSortType);
 }
 
 function handleReadFilterChange(handleSetFlag) {
-  return newReadFilter => handleSetFlag("READ_FILTER", newReadFilter);
+  return newReadFilter => handleSetFlag("sortType", newReadFilter);
 }
 
 function handleDownloadedFilterChange(handleSetFlag) {
   return newDownloadedFilter =>
-    handleSetFlag("DOWNLOADED_FILTER", newDownloadedFilter);
+    handleSetFlag("downloadedFilter", newDownloadedFilter);
 }
 
 export default MangaInfoHeader;

--- a/src/components/MangaInfo/MangaInfoHeader.js
+++ b/src/components/MangaInfo/MangaInfoHeader.js
@@ -99,7 +99,7 @@ function handleSortTypeChange(handleSetFlag) {
 }
 
 function handleReadFilterChange(handleSetFlag) {
-  return newReadFilter => handleSetFlag("sortType", newReadFilter);
+  return newReadFilter => handleSetFlag("readFilter", newReadFilter);
 }
 
 function handleDownloadedFilterChange(handleSetFlag) {

--- a/src/components/MangaInfo/MangaInfoHeader.js
+++ b/src/components/MangaInfo/MangaInfoHeader.js
@@ -84,8 +84,10 @@ const MangaInfoHeader = ({
 };
 
 function handleSortClick(handleSetFlag, flags) {
-  return () =>
-    setFlag("sortDirection", flags.sortDirection === "DESC" ? "ASC" : "DESC");
+  return () => {
+    const newSortDirection = flags.sortDirection === "DESC" ? "ASC" : "DESC";
+    handleSetFlag("sortDirection", newSortDirection);
+  };
 }
 
 function handleDisplayModeChange(handleSetFlag) {

--- a/src/components/MangaInfo/MangaInfoMore.js
+++ b/src/components/MangaInfo/MangaInfoMore.js
@@ -21,7 +21,7 @@ const sortingModes = [
 ];
 
 type Props = {
-  sourceUrl: string,
+  sourceUrl: ?string,
   flags: MangaInfoFlagsType,
   onDisplayModeChange: Function,
   onSortTypeChange: Function
@@ -75,6 +75,7 @@ class MangaInfoMore extends React.Component<Props, State> {
 
   render() {
     const { anchorEl } = this.state;
+    const { sourceUrl } = this.props;
 
     return (
       <>
@@ -98,18 +99,20 @@ class MangaInfoMore extends React.Component<Props, State> {
           <MenuItem onClick={this.handleSortTypeClick}>Sorting Mode</MenuItem>
           {/* <MenuItem>Download</MenuItem> */}
 
-          <MenuItem component="a" href={this.props.sourceUrl} target="_blank">
-            <ListItemIcon>
-              <Icon>open_in_new</Icon>
-            </ListItemIcon>
-            <ListItemText primary="Open source website" />
-          </MenuItem>
+          {sourceUrl != null ? (
+            <MenuItem component="a" href={sourceUrl} target="_blank">
+              <ListItemIcon>
+                <Icon>open_in_new</Icon>
+              </ListItemIcon>
+              <ListItemText primary="Open source website" />
+            </MenuItem>
+          ) : null}
         </Menu>
 
         <RadioOptionsDialogue
           title="Choose Display Mode"
           open={this.state.displayModeOpen}
-          value={this.props.flags.DISPLAY_MODE}
+          value={this.props.flags.displayMode}
           options={displayModes}
           onClose={this.handleDisplayModeClose}
         />
@@ -117,7 +120,7 @@ class MangaInfoMore extends React.Component<Props, State> {
         <RadioOptionsDialogue
           title="Sorting Mode"
           open={this.state.sortTypeOpen}
-          value={this.props.flags.SORT_TYPE}
+          value={this.props.flags.sortType}
           options={sortingModes}
           onClose={this.handleSortTypeClose}
         />

--- a/src/components/MangaInfo/MangaInfoMore.js
+++ b/src/components/MangaInfo/MangaInfoMore.js
@@ -4,7 +4,7 @@ import Icon from "@material-ui/core/Icon";
 import IconButton from "@material-ui/core/IconButton";
 import Menu from "@material-ui/core/Menu";
 import MenuItem from "@material-ui/core/MenuItem";
-import type { MangaInfoFlagsType } from "types";
+import type { MangaFlags } from "@tachiweb/api-client";
 import Tooltip from "@material-ui/core/Tooltip";
 import ListItemIcon from "@material-ui/core/ListItemIcon";
 import ListItemText from "@material-ui/core/ListItemText";
@@ -22,7 +22,7 @@ const sortingModes = [
 
 type Props = {
   sourceUrl: ?string,
-  flags: MangaInfoFlagsType,
+  flags: MangaFlags,
   onDisplayModeChange: Function,
   onSortTypeChange: Function
 };
@@ -57,7 +57,8 @@ class MangaInfoMore extends React.Component<Props, State> {
   handleDisplayModeClose = (value: ?string) => {
     this.setState({ displayModeOpen: false });
     if (value) {
-      this.props.onDisplayModeChange(value);
+      const { onDisplayModeChange } = this.props;
+      onDisplayModeChange(value);
     }
   };
 
@@ -69,13 +70,17 @@ class MangaInfoMore extends React.Component<Props, State> {
   handleSortTypeClose = (value: ?string) => {
     this.setState({ sortTypeOpen: false });
     if (value) {
-      this.props.onSortTypeChange(value);
+      const { onSortTypeChange } = this.props;
+      onSortTypeChange(value);
     }
   };
 
   render() {
-    const { anchorEl } = this.state;
-    const { sourceUrl } = this.props;
+    const { anchorEl, displayModeOpen, sortTypeOpen } = this.state;
+    const {
+      sourceUrl,
+      flags: { displayMode, sortType }
+    } = this.props;
 
     return (
       <>
@@ -111,16 +116,16 @@ class MangaInfoMore extends React.Component<Props, State> {
 
         <RadioOptionsDialogue
           title="Choose Display Mode"
-          open={this.state.displayModeOpen}
-          value={this.props.flags.displayMode}
+          open={displayModeOpen}
+          value={displayMode}
           options={displayModes}
           onClose={this.handleDisplayModeClose}
         />
 
         <RadioOptionsDialogue
           title="Sorting Mode"
-          open={this.state.sortTypeOpen}
-          value={this.props.flags.sortType}
+          open={sortTypeOpen}
+          value={sortType}
           options={sortingModes}
           onClose={this.handleSortTypeClose}
         />

--- a/src/components/MangaInfo/index.js
+++ b/src/components/MangaInfo/index.js
@@ -58,7 +58,9 @@ const MangaInfo = ({ backUrl, defaultTab, match: { params } }: Props) => {
   const chapters = useSelector(state =>
     selectFilteredSortedChapters(state, mangaId)
   );
-  const source = useSelector(state => selectSource(state, mangaInfo.sourceId));
+  const source = useSelector(state =>
+    selectSource(state, mangaInfo ? mangaInfo.sourceId : "")
+  );
   const isMangaInfosLoading = useSelector(selectIsMangaInfosLoading);
   const isChaptersLoading = useSelector(selectIsChaptersLoading);
 

--- a/src/components/MangaInfo/index.js
+++ b/src/components/MangaInfo/index.js
@@ -1,6 +1,6 @@
 // @flow
 import React, { useEffect, useState, type Node } from "react";
-import type { MangaType } from "types";
+import type { Manga, Source } from "@tachiweb/api-client";
 import { Helmet } from "react-helmet";
 import MangaInfoHeader from "components/MangaInfo/MangaInfoHeader";
 import MangaInfoDetails from "components/MangaInfo/MangaInfoDetails";
@@ -27,6 +27,8 @@ import {
   updateChapters
 } from "redux-ducks/chapters/actionCreators";
 import { makeStyles } from "@material-ui/styles";
+import { fetchSources } from "redux-ducks/sources/actionCreators";
+import { selectSource } from "redux-ducks/sources";
 
 type Props = {
   backUrl: string,
@@ -57,6 +59,7 @@ const MangaInfo = ({ backUrl, defaultTab, match: { params } }: Props) => {
   const chapters = useSelector(state =>
     selectFilteredSortedChapters(state, mangaId)
   );
+  const source = useSelector(state => selectSource(state, mangaInfo.sourceId));
   const isMangaInfosLoading = useSelector(selectIsMangaInfosLoading);
   const isChaptersLoading = useSelector(selectIsChaptersLoading);
 
@@ -65,38 +68,30 @@ const MangaInfo = ({ backUrl, defaultTab, match: { params } }: Props) => {
   const store = useStore();
 
   useEffect(() => {
-    dispatch(fetchChapters(mangaId))
-      .then(() => {
-        // The first time a manga is loaded by the server, it will not have any chapters scraped.
-        // So check if we found any chapters. If not, try scraping the site once.
+    dispatch(fetchChapters(mangaId)).then(() => {
+      // The first time a manga is loaded by the server, it will not have any chapters scraped.
+      // So check if we found any chapters. If not, try scraping the site once.
 
-        // Check for chapters directly in the store instead of relying on useSelector().
-        // This is because the useSelector() value doesn't update until the next render
-        // which occurs AFTER this useEffect() promise runs.
-        const chaptersInStore = selectChaptersForManga(
-          store.getState(),
-          mangaId
-        );
+      // Check for chapters directly in the store instead of relying on useSelector().
+      // This is because the useSelector() value doesn't update until the next render
+      // which occurs AFTER this useEffect() promise runs.
+      const chaptersInStore = selectChaptersForManga(store.getState(), mangaId);
 
-        if (!chaptersInStore.length) {
-          // return promise so next .then()'s wait until the data has finished fetching
-          return dispatch(updateChapters(mangaId));
-        }
-        return null;
-      })
-      .then(() => dispatch(fetchMangaInfo(mangaId)))
-      .then(() => {
-        // If we think the server hasn't had enough time to scrape the source website
-        // for this mangaInfo, wait a little while and try fetching again.
-        //
-        // NOTE: This only updates the manga being viewed. Many of your other search results are
-        //       likely missing information as well. Viewing them will then fetch the data.
-        //
-        // TODO: might try to do one additional fetch at a slightly later time. e.g. 1000 ms
-        if (mangaInfo && possiblyMissingInfo(mangaInfo)) {
-          setTimeout(() => dispatch(updateMangaInfo(mangaId)), 300);
-        }
-      });
+      if (!chaptersInStore.length) {
+        // return promise so next .then()'s wait until the data has finished fetching
+        return dispatch(updateChapters(mangaId));
+      }
+      return null;
+    });
+
+    dispatch(fetchMangaInfo(mangaId)).then(() => {
+      // Update manga manually if the server has not fetched the data for this manga yet
+      if (mangaInfo && !mangaInfo.initialized) {
+        dispatch(updateMangaInfo(mangaId));
+      }
+
+      dispatch(fetchSources());
+    });
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   const handleChangeTab = (event: SyntheticEvent<>, newValue: number) => {
@@ -108,7 +103,11 @@ const MangaInfo = ({ backUrl, defaultTab, match: { params } }: Props) => {
 
     if (mangaInfo && tabValue === 0) {
       return (
-        <MangaInfoDetails mangaInfo={mangaInfo} numChapters={numChapters} />
+        <MangaInfoDetails
+          mangaInfo={mangaInfo}
+          numChapters={numChapters}
+          source={source}
+        />
       );
     }
     if (mangaInfo && tabValue === 1) {
@@ -144,24 +143,5 @@ const MangaInfo = ({ backUrl, defaultTab, match: { params } }: Props) => {
     </div>
   );
 };
-
-// Helper methods
-function possiblyMissingInfo(manga: MangaType): boolean {
-  // mangaFields is an array of some values that mangaInfo should probably have
-  // Count the number of these fields that are missing
-  const mangaFields = ["author", "description", "genres", "categories"];
-
-  const numMissing = mangaFields.reduce((counter, field) => {
-    const value = manga[field];
-
-    if (!value || (Array.isArray(value) && !value.length)) {
-      return counter + 1;
-    }
-    return counter;
-  }, 0);
-
-  // setting the arbitrary amount of missing info at 3 to be considered missing info
-  return numMissing >= 3;
-}
 
 export default MangaInfo;

--- a/src/components/MangaInfo/index.js
+++ b/src/components/MangaInfo/index.js
@@ -1,6 +1,5 @@
 // @flow
 import React, { useEffect, useState, type Node } from "react";
-import type { Manga, Source } from "@tachiweb/api-client";
 import { Helmet } from "react-helmet";
 import MangaInfoHeader from "components/MangaInfo/MangaInfoHeader";
 import MangaInfoDetails from "components/MangaInfo/MangaInfoDetails";

--- a/src/components/Reader/index.js
+++ b/src/components/Reader/index.js
@@ -4,7 +4,8 @@ import { useSelector, useDispatch } from "react-redux";
 import { Server, Client } from "api";
 import FullScreenLoading from "components/Loading/FullScreenLoading";
 import compact from "lodash/compact";
-import type { ChapterType, MangaType } from "types";
+import type { Manga } from "@tachiweb/api-client";
+import type { ChapterType } from "types";
 import SinglePageReader from "components/Reader/SinglePageReader";
 import WebtoonReader from "components/Reader/WebtoonReader";
 import ReadingStatusUpdater from "components/Reader/ReadingStatusUpdater";
@@ -180,7 +181,7 @@ const Reader = ({ match: { params } }: Props) => {
 // Helper methods
 function changeChapterUrl(
   urlPrefix: string,
-  mangaInfo: ?MangaType,
+  mangaInfo: ?Manga,
   newChapterId: ?number,
   chapters: Array<ChapterType>
 ): ?string {

--- a/src/redux-ducks/catalogue/actionCreators.js
+++ b/src/redux-ducks/catalogue/actionCreators.js
@@ -2,6 +2,7 @@
 import { Server } from "api";
 import type { ThunkAction } from "redux-ducks/reducers";
 import type { CataloguePageRequest } from "@tachiweb/api-client";
+import type { FilterAnyType } from "types/filters";
 import { ADD_MANGA } from "redux-ducks/mangaInfos/actions";
 import { selectLastUsedFilters } from "redux-ducks/filters";
 import { transformToMangaIdsArray } from "redux-ducks/utils";
@@ -165,8 +166,8 @@ export function changeSourceId(newSourceId: string): ChangeSourceIdAction {
 // ================================================================================
 function catalogueRequest(
   page: number,
-  query?: string,
-  filters?: Object
+  query: string,
+  filters: ?$ReadOnlyArray<FilterAnyType>
 ): CataloguePageRequest {
   const request: CataloguePageRequest = {
     page,
@@ -174,7 +175,9 @@ function catalogueRequest(
   };
 
   // filters field cannot exist in request if no filters (even null is not allowed)
-  if (filters != null) request.filters = JSON.stringify(filters);
+  if (filters != null) {
+    request.filters = JSON.stringify(filters);
+  }
 
   return request;
 }

--- a/src/redux-ducks/catalogue/index.js
+++ b/src/redux-ducks/catalogue/index.js
@@ -1,6 +1,6 @@
 // @flow
 import type { GlobalState, Action } from "redux-ducks/reducers";
-import type { MangaType } from "types";
+import type { Manga } from "@tachiweb/api-client";
 import { createLoadingSelector } from "redux-ducks/loading";
 import { createSelector } from "reselect";
 import { selectMangaInfos } from "redux-ducks/mangaInfos";
@@ -105,7 +105,7 @@ export const selectCatalogueSearchQuery = (state: GlobalState): string =>
 
 export const selectCatalogueMangaInfos = createSelector(
   [selectMangaInfos, selectCatalogueMangaIds],
-  (mangaInfos, mangaIds): Array<MangaType> => {
+  (mangaInfos, mangaIds): Array<Manga> => {
     return mangaIds.map(mangaId => mangaInfos[mangaId]);
   }
 );

--- a/src/redux-ducks/chapters/chapterUtils.js
+++ b/src/redux-ducks/chapters/chapterUtils.js
@@ -1,5 +1,6 @@
 // @flow
-import type { MangaInfoFlagsType, ChapterType } from "types";
+import type { ChapterType } from "types";
+import type { MangaFlags } from "@tachiweb/api-client";
 
 const sortFuncs = {
   SOURCE: (a, b) => b.source_order - a.source_order,
@@ -8,41 +9,41 @@ const sortFuncs = {
 
 // READ shows chapters you've completed, UNREAD shows uncompleted chapters
 const readFilterFuncs = {
-  ALL: () => true,
-  READ: chapter => chapter.read,
-  UNREAD: chapter => !chapter.read
+  SHOW_ALL: () => true,
+  SHOW_READ: chapter => chapter.read,
+  SHOW_UNREAD: chapter => !chapter.read
 };
 
 const downloadedFilterFuncs = {
-  ALL: () => true,
-  DOWNLOADED: chapter => chapter.download_status === "DOWNLOADED",
-  NOT_DOWNLOADED: chapter => chapter.download_status === "NOT_DOWNLOADED" // unused
+  SHOW_ALL: () => true,
+  SHOW_DOWNLOADED: chapter => chapter.download_status === "DOWNLOADED",
+  SHOW_NOT_DOWNLOADED: chapter => chapter.download_status === "NOT_DOWNLOADED" // unused
 };
 
 function filterChapters(
   chapters: Array<ChapterType>,
-  mangaInfoFlags: MangaInfoFlagsType
+  mangaInfoFlags: MangaFlags
 ) {
-  const { READ_FILTER, DOWNLOADED_FILTER } = mangaInfoFlags;
+  const { readFilter, downloadedFilter } = mangaInfoFlags;
 
   return chapters
     .slice() // clone array
-    .filter(readFilterFuncs[READ_FILTER])
-    .filter(downloadedFilterFuncs[DOWNLOADED_FILTER]);
+    .filter(readFilterFuncs[readFilter])
+    .filter(downloadedFilterFuncs[downloadedFilter]);
 }
 
 function sortChapters(
   chapters: Array<ChapterType>,
-  mangaInfoFlags: MangaInfoFlagsType
+  mangaInfoFlags: MangaFlags
 ) {
-  const { SORT_TYPE, SORT_DIRECTION } = mangaInfoFlags;
+  const { sortType, sortDirection } = mangaInfoFlags;
 
   let sortedChapters: Array<ChapterType> = chapters
     .slice() // clone array
-    .sort(sortFuncs[SORT_TYPE]);
+    .sort(sortFuncs[sortType]);
 
   // The manga chapters naturally come in ascending order
-  if (SORT_DIRECTION === "DESCENDING") {
+  if (sortDirection === "DESC") {
     sortedChapters = sortedChapters.reverse();
   }
 
@@ -51,7 +52,7 @@ function sortChapters(
 
 export default function filterSortChapters(
   chapters: Array<ChapterType>,
-  mangaInfoFlags: MangaInfoFlagsType
+  mangaInfoFlags: MangaFlags
 ) {
   const filteredChapters = filterChapters(chapters, mangaInfoFlags);
   return sortChapters(filteredChapters, mangaInfoFlags);

--- a/src/redux-ducks/chapters/index.js
+++ b/src/redux-ducks/chapters/index.js
@@ -1,6 +1,7 @@
 // @flow
 import type { GlobalState, Action } from "redux-ducks/reducers";
-import type { ChapterType, MangaType } from "types";
+import type { ChapterType } from "types";
+import type { Manga } from "@tachiweb/api-client";
 import createCachedSelector from "re-reselect";
 import { createLoadingSelector } from "redux-ducks/loading";
 import { selectMangaInfo } from "redux-ducks/mangaInfos";
@@ -92,7 +93,7 @@ export const selectChapter = createCachedSelector(
 // selectFilteredSortedChapters(state, mangaId)
 export const selectFilteredSortedChapters = createCachedSelector(
   [selectMangaInfo, selectChaptersForManga],
-  (mangaInfo: ?MangaType, chapters: Array<ChapterType>) => {
+  (mangaInfo: ?Manga, chapters: Array<ChapterType>) => {
     if (!mangaInfo) return noChapters;
     return filterSortChapters(chapters, mangaInfo.flags);
   }

--- a/src/redux-ducks/extensions/actionCreators.js
+++ b/src/redux-ducks/extensions/actionCreators.js
@@ -3,7 +3,6 @@ import { Server } from "api";
 import type { ThunkAction } from "redux-ducks/reducers";
 import type { ExtensionType } from "types";
 import { REMOVE_SOURCES } from "redux-ducks/sources/actions";
-import { fetchSources } from "redux-ducks/sources/actionCreators";
 import { RESET_STATE as RESET_CATALOGUE_STATE } from "redux-ducks/catalogue/actions";
 import {
   FETCH_REQUEST,

--- a/src/redux-ducks/extensions/actionCreators.js
+++ b/src/redux-ducks/extensions/actionCreators.js
@@ -61,10 +61,6 @@ export function installExtension(packageName: string): ThunkAction {
 
       dispatch({ type: INSTALL_SUCCESS, extension });
       dispatch({ type: RESET_CATALOGUE_STATE });
-
-      // When a new extension is installed, new sources are added and we
-      // don't know what those sources are so we have to fetch them.
-      await dispatch(fetchSources());
     } catch (error) {
       dispatch({
         type: INSTALL_FAILURE,

--- a/src/redux-ducks/library/actionCreators.js
+++ b/src/redux-ducks/library/actionCreators.js
@@ -132,8 +132,9 @@ export function updateLibrary(): ThunkAction {
     );
 
     return serialPromiseChain(updateChapterPromises).then(() => {
+      // [June 16, 2019 -- nulldev]
+      // Will always load the unread if ignoring the cache, so no need to call fetchUnread()
       dispatch(fetchLibrary({ ignoreCache: true }));
-      dispatch(fetchUnread({ ignoreCache: true }));
     });
   };
 }

--- a/src/redux-ducks/library/actions.js
+++ b/src/redux-ducks/library/actions.js
@@ -25,7 +25,10 @@ type FetchLibraryRequestAction = { type: FETCH_LIBRARY_REQUEST_TYPE };
 
 type FetchLibrarySuccessAction = {
   type: FETCH_LIBRARY_SUCCESS_TYPE,
-  mangaIds: Array<number>
+  mangaIds: Array<number>,
+  downloaded: $ReadOnly<{ [index: number]: number }>,
+  totalChaptersSortIndexes: $ReadOnly<{ [index: number]: number }>,
+  lastReadSortIndexes: $ReadOnly<{ [index: number]: number }>
 };
 
 type FetchLibraryFailureAction = {

--- a/src/redux-ducks/library/index.js
+++ b/src/redux-ducks/library/index.js
@@ -1,11 +1,16 @@
 // @flow
+import type { Manga } from "@tachiweb/api-client";
+import type { LibraryFlagsType } from "types";
 import type { GlobalState, Action } from "redux-ducks/reducers";
-import type { MangaType, LibraryFlagsType } from "types";
 import { selectMangaInfos } from "redux-ducks/mangaInfos";
 import { createLoadingSelector } from "redux-ducks/loading";
 import { createErrorSelector } from "redux-ducks/error";
 import { createSelector } from "reselect";
 import createCachedSelector from "re-reselect";
+import {
+  UPDATE_SUCCESS as UPDATE_CHAPTERS_SUCCESS,
+  UPDATE_READING_STATUS_SUCCESS
+} from "redux-ducks/chapters/actions";
 import filterSortLibrary from "./libraryUtils";
 import {
   FETCH_LIBRARY,
@@ -29,7 +34,12 @@ type State = $ReadOnly<{
   mangaIds: $ReadOnlyArray<number>,
   reloadLibrary: boolean,
   unread: $ReadOnly<{ [mangaId: number]: number }>,
+  downloaded: $ReadOnly<{ [mangaId: number]: number }>,
+  totalChaptersSortIndexes: $ReadOnly<{ [index: number]: number }>,
+  lastReadSortIndexes: $ReadOnly<{ [index: number]: number }>,
   reloadUnread: boolean,
+  reloadTotalChaptersSortIndexes: boolean,
+  reloadLastReadSortIndexes: boolean,
   flags: LibraryFlagsType,
   isFlagsLoaded: boolean
 }>;
@@ -37,8 +47,14 @@ type State = $ReadOnly<{
 const defaultState: State = {
   mangaIds: [], // array of mangaIds that point at data loaded in mangaInfos reducer
   reloadLibrary: true, // Library should be loaded once on first visit
-  unread: {}, // { mangaId: int }
+  unread: {},
+  downloaded: {},
+  totalChaptersSortIndexes: {},
+  lastReadSortIndexes: {},
   reloadUnread: true, // should refresh unread for library if something new is added
+  reloadDownloaded: true,
+  reloadTotalChaptersSortIndexes: true,
+  reloadLastReadSortIndexes: true,
   flags: {
     filters: [
       {
@@ -87,7 +103,10 @@ export default function libraryReducer(
       return {
         ...state,
         mangaIds: [...state.mangaIds, action.mangaId],
-        reloadUnread: true
+        reloadUnread: true,
+        reloadDownloaded: true,
+        reloadTotalChaptersSortIndexes: true,
+        reloadLastReadSortIndexes: true
       };
 
     case REMOVE_FROM_FAVORITES: {
@@ -118,7 +137,10 @@ export default function libraryReducer(
         ...state,
         reloadLibrary: true,
         reloadUnread: true,
-        isFlagsLoaded: false
+        isFlagsLoaded: false,
+        reloadDownloaded: true,
+        reloadTotalChaptersSortIndexes: true,
+        reloadLastReadSortIndexes: true
       };
 
     case FETCH_LIBRARY_FLAGS_SUCCESS:
@@ -135,6 +157,19 @@ export default function libraryReducer(
           ...state.flags,
           [action.flag]: action.value
         }
+      };
+
+    case UPDATE_CHAPTERS_SUCCESS:
+      return {
+        ...state,
+        reloadUnread: true,
+        reloadTotalChaptersSortIndexes: true
+      };
+
+    case UPDATE_READING_STATUS_SUCCESS:
+      return {
+        ...state,
+        reloadLastReadSortIndexes: true
       };
 
     default:
@@ -168,7 +203,7 @@ export const selectLibraryFlags = (state: GlobalState): LibraryFlagsType =>
 
 export const selectLibraryMangaInfos = createSelector(
   [selectMangaInfos, selectLibraryMangaIds],
-  (mangaInfos, mangaIds): Array<MangaType> => {
+  (mangaInfos, mangaIds): Array<Manga> => {
     return mangaIds.map(mangaId => mangaInfos[mangaId]);
   }
 );

--- a/src/redux-ducks/library/index.js
+++ b/src/redux-ducks/library/index.js
@@ -11,6 +11,7 @@ import {
   UPDATE_SUCCESS as UPDATE_CHAPTERS_SUCCESS,
   UPDATE_READING_STATUS_SUCCESS
 } from "redux-ducks/chapters/actions";
+import { selectSources } from "redux-ducks/sources";
 import filterSortLibrary from "./libraryUtils";
 import {
   FETCH_LIBRARY,
@@ -213,7 +214,13 @@ export const selectFilteredSortedLibrary = createCachedSelector(
   [
     selectLibraryMangaInfos,
     selectLibraryFlags,
+    selectSources,
     selectUnread,
+    // [June 16, 2019] Too lazy to make individual selectors for each of these right now.
+    (state: GlobalState) => state.library.downloaded,
+    (state: GlobalState) => state.library.totalChaptersSortIndexes,
+    (state: GlobalState) => state.library.lastReadSortIndexes,
+    // ------
     (_, searchQuery) => searchQuery
   ],
   filterSortLibrary

--- a/src/redux-ducks/library/libraryUtils.js
+++ b/src/redux-ducks/library/libraryUtils.js
@@ -1,10 +1,11 @@
 // @flow
 import type {
-  MangaType,
   LibraryFlagsType,
   LibraryFlagsSortType,
-  LibraryFlagsFiltersType
+  LibraryFlagsFiltersType,
+  SourceMap
 } from "types";
+import type { Manga } from "@tachiweb/api-client";
 
 // TODO: Consider using a fuzzy search package for the search filter
 
@@ -19,8 +20,32 @@ function stringComparison(a: string, b: string) {
 //       to them (even though sortFuncs only needs it for one type).
 
 // If whatever sort comparison is equal, fallback on ordering by title
-const sortFuncs = unread => ({
+const sortFuncs = (
+  totalMangaCount,
+  sources,
+  unread,
+  totalChaptersSortIndexes,
+  lastReadSortIndexes
+) => ({
   ALPHA: (a, b) => stringComparison(a.title, b.title),
+  LAST_READ: (a, b) => {
+    let aIndex = lastReadSortIndexes[a.id];
+    let bIndex = lastReadSortIndexes[b.id];
+    // Push manga that were never read to the back
+    if (aIndex == null) aIndex = totalMangaCount;
+    if (bIndex == null) bIndex = totalMangaCount;
+
+    if (aIndex !== bIndex) {
+      return aIndex - bIndex;
+    }
+    return stringComparison(a.title, b.title);
+  },
+  LAST_UPDATED: (a, b) => {
+    if (a.lastUpdate !== b.lastUpdate) {
+      return a.lastUpdate - b.lastUpdate;
+    }
+    return stringComparison(a.title, b.title);
+  },
   UNREAD: (a, b) => {
     if (unread[a.id] !== unread[b.id]) {
       return unread[a.id] - unread[b.id];
@@ -28,23 +53,27 @@ const sortFuncs = unread => ({
     return stringComparison(a.title, b.title);
   },
   TOTAL: (a, b) => {
-    if (a.chapters == null || b.chapters == null) return 0;
+    let aIndex = totalChaptersSortIndexes[a.id];
+    let bIndex = totalChaptersSortIndexes[b.id];
+    // Push manga that have 0 or unknown chapters to the front
+    if (aIndex == null) aIndex = 0;
+    if (bIndex == null) bIndex = 0;
 
-    if (a.chapters !== b.chapters) {
-      return a.chapters - b.chapters;
+    if (aIndex !== bIndex) {
+      return aIndex - bIndex;
     }
     return stringComparison(a.title, b.title);
   },
   SOURCE: (a, b) => {
-    if (a.source !== b.source) {
-      return stringComparison(a.source, b.source);
+    // Use source ID as source title if the source is not loaded
+    const aSource = sources[a.sourceId] || { name: a.sourceId };
+    const bSource = sources[b.sourceId] || { name: b.sourceId };
+
+    if (aSource !== bSource) {
+      return stringComparison(aSource.name, bSource.name);
     }
     return stringComparison(a.title, b.title);
   }
-
-  // TODO: I don't think I have or can easily get the data needed for these sorts
-  // LAST_READ: ,
-  // LAST_UPDATED: ,
 });
 
 // Not using the EXCLUDE option for these filters
@@ -53,30 +82,40 @@ const readFilterFuncs = unread => ({
   INCLUDE: mangaInfo => unread[mangaInfo.id] // 0 (or null/undefined) will be false
 });
 
-const downloadedFilterFuncs = {
+const downloadedFilterFuncs = downloaded => ({
   ANY: () => true,
-  INCLUDE: mangaInfo => mangaInfo.downloaded
-};
+  INCLUDE: mangaInfo => downloaded[mangaInfo.id]
+});
 
 const completedFilterFuncs = {
   ANY: () => true,
 
-  // is "Completed" always formatted exactly like this?
-  INCLUDE: mangaInfo => mangaInfo.status === "Completed"
+  INCLUDE: mangaInfo => mangaInfo.status === "COMPLETED"
 };
 
 const searchFilterFunc = searchQuery => mangaInfo =>
   mangaInfo.title.toUpperCase().includes(searchQuery.toUpperCase());
 
 function sortLibrary(
-  mangaLibrary: Array<MangaType>,
+  mangaLibrary: Array<Manga>,
   sortFlags: LibraryFlagsSortType,
-  unread: { [mangaId: number]: number }
+  sources: SourceMap,
+  unread: { [mangaId: number]: number },
+  totalChaptersSortIndexes: { [mangaId: number]: number },
+  lastReadSortIndexes: { [mangaId: number]: number }
 ) {
   const { type, direction } = sortFlags;
-  let sortedLibrary: Array<MangaType> = mangaLibrary
+  let sortedLibrary: Array<Manga> = mangaLibrary
     .slice() // clone array
-    .sort(sortFuncs(unread)[type]);
+    .sort(
+      sortFuncs(
+        mangaLibrary.length,
+        sources,
+        unread,
+        totalChaptersSortIndexes,
+        lastReadSortIndexes
+      )[type]
+    );
 
   if (direction === "DESCENDING") {
     sortedLibrary = sortedLibrary.reverse();
@@ -86,31 +125,44 @@ function sortLibrary(
 }
 
 function filterLibrary(
-  mangaLibrary: Array<MangaType>,
+  mangaLibrary: Array<Manga>,
   filterFlags: LibraryFlagsFiltersType,
   unread: { [mangaId: number]: number },
+  downloaded: { [mangaId: number]: number },
   searchQuery: string
 ) {
-  const [downloadedFilter, unreadFilter, completedFilter] = filterFlags;
+  const [DOWNLOADED, UNREAD, COMPLETED] = filterFlags;
   return mangaLibrary
     .slice() // clone array
-    .filter(readFilterFuncs(unread)[unreadFilter.status])
-    .filter(downloadedFilterFuncs[downloadedFilter.status])
-    .filter(completedFilterFuncs[completedFilter.status])
+    .filter(downloadedFilterFuncs(downloaded)[DOWNLOADED.status])
+    .filter(readFilterFuncs(unread)[UNREAD.status])
+    .filter(completedFilterFuncs[COMPLETED.status])
     .filter(searchFilterFunc(searchQuery));
 }
 
 export default function filterSortLibrary(
-  mangaLibrary: Array<MangaType>,
+  mangaLibrary: Array<Manga>,
   libraryFlags: LibraryFlagsType,
+  sources: SourceMap,
   unread: { [mangaId: number]: number },
+  downloaded: { [mangaId: number]: number },
+  totalChaptersSortIndexes: { [mangaId: number]: number },
+  lastReadSortIndexes: { [mangaId: number]: number },
   searchQuery: string
 ) {
   const filteredLibrary = filterLibrary(
     mangaLibrary,
     libraryFlags.filters,
     unread,
+    downloaded,
     searchQuery
   );
-  return sortLibrary(filteredLibrary, libraryFlags.sort, unread);
+  return sortLibrary(
+    filteredLibrary,
+    libraryFlags.sort,
+    sources,
+    unread,
+    totalChaptersSortIndexes,
+    lastReadSortIndexes
+  );
 }

--- a/src/redux-ducks/mangaInfos/actions.js
+++ b/src/redux-ducks/mangaInfos/actions.js
@@ -136,7 +136,7 @@ type SET_FLAG_NO_CHANGE_TYPE = "mangaInfos/SET_FLAG_NO_CHANGE";
 type SetFlagRequestAction = {
   type: SET_FLAG_REQUEST_TYPE,
   mangaId: number,
-  // flag and state correspond with the key value pair of MangaInfoFlagsType
+  // flag and state correspond with the key value pair of MangaFlags
   // No obvious way to automatically type this in Flow
   flag: string,
   state: string

--- a/src/redux-ducks/mangaInfos/actions.js
+++ b/src/redux-ducks/mangaInfos/actions.js
@@ -1,5 +1,5 @@
 // @flow
-import type { MangaType } from "types";
+import type { Manga } from "@tachiweb/api-client";
 
 // ================================================================================
 // Fetch Manga
@@ -25,7 +25,7 @@ type FetchMangaRequestAction = { type: FETCH_MANGA_REQUEST_TYPE, meta: Object };
 
 type FetchMangaSuccessAction = {
   type: FETCH_MANGA_SUCCESS_TYPE,
-  mangaInfo: MangaType
+  mangaInfo: Manga
 };
 
 type FetchMangaFailureAction = {
@@ -61,7 +61,7 @@ type UpdateMangaRequestAction = {
 type UpdateMangaSuccessAction = {
   // This indicates the manga has been rescraped. You should fetch it again after this.
   type: UPDATE_MANGA_SUCCESS_TYPE,
-  meta: Object
+  mangaInfo: Manga
 };
 
 type UpdateMangaFailureAction = {
@@ -112,7 +112,7 @@ type ADD_MANGA_TYPE = "mangaInfos/ADD_MANGA";
 
 export type AddMangaAction = {
   type: ADD_MANGA_TYPE,
-  newManga: Array<MangaType>
+  newManga: Array<Manga>
 };
 
 // ================================================================================

--- a/src/redux-ducks/mangaInfos/index.js
+++ b/src/redux-ducks/mangaInfos/index.js
@@ -1,5 +1,5 @@
 // @flow
-import type { MangaType, MangaInfoFlagsType } from "types";
+import type { Manga } from "@tachiweb/api-client";
 import { createLoadingSelector } from "redux-ducks/loading";
 import createCachedSelector from "re-reselect";
 import type { GlobalState, Action } from "redux-ducks/reducers";
@@ -24,7 +24,7 @@ import {
 // ================================================================================
 // Reducer
 // ================================================================================
-type State = $ReadOnly<{ [mangaId: number]: MangaType }>;
+type State = $ReadOnly<{ [mangaId: number]: Manga }>;
 
 export default function mangaInfosReducer(
   state: State = {},
@@ -41,7 +41,7 @@ export default function mangaInfosReducer(
       return { ...state, [action.mangaInfo.id]: action.mangaInfo };
 
     case UPDATE_MANGA_SUCCESS:
-      return state;
+      return { ...state, [action.mangaInfo.id]: action.mangaInfo };
 
     case TOGGLE_FAVORITE_SUCCESS:
       return {
@@ -84,10 +84,8 @@ export const selectIsFavoriteToggling = createLoadingSelector([
 
 export const selectMangaInfos = (state: GlobalState): State => state.mangaInfos;
 
-export const selectMangaInfo = (
-  state: GlobalState,
-  mangaId: number
-): ?MangaType => state.mangaInfos[mangaId];
+export const selectMangaInfo = (state: GlobalState, mangaId: number): ?Manga =>
+  state.mangaInfos[mangaId];
 
 // selectIsFavorite(state, mangaId: number)
 // returns boolean
@@ -101,16 +99,13 @@ export const selectIsFavorite = createCachedSelector(
   // Cache Key
 )((state, mangaId) => mangaId);
 
-export const selectMangaFlagValue = (
-  state: GlobalState,
-  mangaId: number,
-  flag: $Keys<MangaInfoFlagsType>
-) => state.mangaInfos[mangaId].flags[flag];
+export const selectMangaFlags = (state: GlobalState, mangaId: number) =>
+  state.mangaInfos[mangaId].flags;
 
 // ================================================================================
 // Helper Functions
 // ================================================================================
-function mangaArrayToObject(mangaArray: Array<MangaType>): State {
+function mangaArrayToObject(mangaArray: Array<Manga>): State {
   const mangaObject = {};
   mangaArray.forEach(manga => {
     mangaObject[manga.id] = manga;

--- a/src/redux-ducks/settings/index.js
+++ b/src/redux-ducks/settings/index.js
@@ -64,11 +64,6 @@ export default function settingsReducers(
         schema: UI_SETTINGS.concat(action.schema)
       };
 
-    case SET_PREF_NO_CHANGE:
-    case FETCH_SCHEMA_CACHE:
-    case FETCH_PREFS_CACHE:
-      return state;
-
     default:
       return state;
   }

--- a/src/redux-ducks/settings/index.js
+++ b/src/redux-ducks/settings/index.js
@@ -7,12 +7,9 @@ import type { PrefValue, PrefsType } from "types";
 import {
   FETCH_PREFS,
   FETCH_PREFS_SUCCESS,
-  FETCH_PREFS_CACHE,
   SET_PREF_REQUEST,
-  SET_PREF_NO_CHANGE,
   FETCH_SCHEMA,
-  FETCH_SCHEMA_SUCCESS,
-  FETCH_SCHEMA_CACHE
+  FETCH_SCHEMA_SUCCESS
 } from "./actions";
 
 // ================================================================================

--- a/src/redux-ducks/sources/actionCreators.js
+++ b/src/redux-ducks/sources/actionCreators.js
@@ -1,11 +1,16 @@
 // @flow
 import { Server } from "api";
-import { handleHTMLError } from "redux-ducks/utils";
+import isEmpty from "lodash/isEmpty";
 import { selectCatalogueSourceId } from "redux-ducks/catalogue";
 import { changeSourceId } from "redux-ducks/catalogue/actionCreators";
 import type { ThunkAction } from "redux-ducks/reducers";
-import type { SourceType } from "types";
-import { FETCH_REQUEST, FETCH_SUCCESS, FETCH_FAILURE } from "./actions";
+import {
+  FETCH_REQUEST,
+  FETCH_SUCCESS,
+  FETCH_FAILURE,
+  FETCH_CACHE
+} from "./actions";
+import { selectSources } from ".";
 
 // ================================================================================
 // Action Creators
@@ -13,18 +18,22 @@ import { FETCH_REQUEST, FETCH_SUCCESS, FETCH_FAILURE } from "./actions";
 // eslint-disable-next-line import/prefer-default-export
 export function fetchSources(): ThunkAction {
   return (dispatch, getState) => {
+    if (!isEmpty(selectSources(getState()))) {
+      return Promise.resolve().then(dispatch({ type: FETCH_CACHE }));
+    }
+
     dispatch({ type: FETCH_REQUEST });
 
-    return fetch(Server.sources())
-      .then(handleHTMLError)
+    return Server.api()
+      .getSources()
       .then(
-        json => {
-          const sources: Array<SourceType> = json.content;
+        sources => {
           dispatch({ type: FETCH_SUCCESS, payload: sources });
 
           // SIDE EFFECT - set the catalogue sourceId on first sources load
-          if (!selectCatalogueSourceId(getState()) && sources.length > 0) {
-            dispatch(changeSourceId(sources[0].id));
+          if (!selectCatalogueSourceId(getState()) && !isEmpty(sources)) {
+            const firstSource = sources[Object.keys(sources)[0]];
+            dispatch(changeSourceId(firstSource.id));
           }
         },
         error =>

--- a/src/redux-ducks/sources/actionCreators.js
+++ b/src/redux-ducks/sources/actionCreators.js
@@ -18,7 +18,15 @@ import { selectSources } from ".";
 // eslint-disable-next-line import/prefer-default-export
 export function fetchSources(): ThunkAction {
   return (dispatch, getState) => {
-    if (!isEmpty(selectSources(getState()))) {
+    const currentSources = selectSources(getState());
+    if (!isEmpty(currentSources)) {
+      // SIDE EFFECT - set the catalogue sourceId if not found
+      if (!selectCatalogueSourceId(getState())) {
+        const firstSource = currentSources[Object.keys(currentSources)[0]];
+        dispatch(changeSourceId(firstSource.id));
+      }
+      // ----------
+
       return Promise.resolve().then(dispatch({ type: FETCH_CACHE }));
     }
 

--- a/src/redux-ducks/sources/actions.js
+++ b/src/redux-ducks/sources/actions.js
@@ -1,5 +1,5 @@
 // @flow
-import type { SourceType } from "types";
+import type { Source } from "@tachiweb/api-client";
 
 // ================================================================================
 // Fetch Sources
@@ -17,12 +17,15 @@ type FETCH_SUCCESS_TYPE = "sources/FETCH_SUCCESS";
 export const FETCH_FAILURE = "sources/FETCH_FAILURE";
 type FETCH_FAILURE_TYPE = "sources/FETCH_FAILURE";
 
+export const FETCH_CACHE = "sources/FETCH_CACHE";
+type FETCH_CACHE_TYPE = "sources/FETCH_CACHE";
+
 // Action Object Types
 type FetchRequestAction = { type: FETCH_REQUEST_TYPE };
 
 type FetchSuccessAction = {
   type: FETCH_SUCCESS_TYPE,
-  payload: $ReadOnlyArray<SourceType>
+  payload: Array<Source>
 };
 
 type FetchFailureAction = {
@@ -31,10 +34,26 @@ type FetchFailureAction = {
   meta: Object
 };
 
+type FetchCacheAction = { type: FETCH_CACHE_TYPE };
+
+// ================================================================================
+// etc actions
+// ================================================================================
+
+export const REMOVE_SOURCES = "sources/REMOVE_SOURCES";
+type REMOVE_SOURCES_TYPE = "sources/REMOVE_SOURCES";
+
+type RemoveSourcesAction = {
+  type: REMOVE_SOURCES_TYPE,
+  sourceIds: ?Array<string>
+};
+
 // ================================================================================
 // Consolidated Action Type
 // ================================================================================
 export type SourcesAction =
   | FetchRequestAction
   | FetchSuccessAction
-  | FetchFailureAction;
+  | FetchFailureAction
+  | FetchCacheAction
+  | RemoveSourcesAction;

--- a/src/redux-ducks/sources/index.js
+++ b/src/redux-ducks/sources/index.js
@@ -1,22 +1,28 @@
 // @flow
 import { createLoadingSelector } from "redux-ducks/loading";
-import type { SourceType } from "types";
+import type { SourceMap } from "types";
+import type { Source } from "@tachiweb/api-client";
 import type { GlobalState, Action } from "redux-ducks/reducers";
-import { FETCH_SOURCES, FETCH_SUCCESS } from "./actions";
+import { withDeletedKeys } from "redux-ducks/utils";
+import { FETCH_SOURCES, FETCH_SUCCESS, REMOVE_SOURCES } from "./actions";
 
 // ================================================================================
 // Reducer
 // ================================================================================
 
-type State = $ReadOnlyArray<SourceType>;
+type State = SourceMap;
 
 export default function sourcesReducer(
-  state: State = [],
+  state: State = {},
   action: Action
 ): State {
   switch (action.type) {
     case FETCH_SUCCESS:
-      return action.payload;
+      return sourceArrayToObject(action.payload);
+
+    case REMOVE_SOURCES:
+      return withDeletedKeys<string, Source>(state, action.sourceIds);
+
     default:
       return state;
   }
@@ -27,5 +33,15 @@ export default function sourcesReducer(
 // ================================================================================
 
 export const selectIsSourcesLoading = createLoadingSelector([FETCH_SOURCES]);
-export const selectSources = (state: GlobalState): $ReadOnlyArray<SourceType> =>
-  state.sources;
+export const selectSources = (state: GlobalState): State => state.sources;
+
+// ================================================================================
+// Helper Functions
+// ================================================================================
+function sourceArrayToObject(sourceArray: Array<Source>): SourceMap {
+  const sourceObject = {};
+  sourceArray.forEach(source => {
+    sourceObject[source.id] = source;
+  });
+  return sourceObject;
+}

--- a/src/redux-ducks/sources/index.js
+++ b/src/redux-ducks/sources/index.js
@@ -33,7 +33,11 @@ export default function sourcesReducer(
 // ================================================================================
 
 export const selectIsSourcesLoading = createLoadingSelector([FETCH_SOURCES]);
+
 export const selectSources = (state: GlobalState): State => state.sources;
+
+export const selectSource = (state: GlobalState, sourceId: string): ?Source =>
+  state.sources[sourceId];
 
 // ================================================================================
 // Helper Functions

--- a/src/redux-ducks/utils.js
+++ b/src/redux-ducks/utils.js
@@ -1,5 +1,5 @@
 // @flow
-import type { MangaType } from "types";
+import type { Manga } from "@tachiweb/api-client";
 
 // TODO: Not sure if these flow types are 100% correct
 export function handleHTMLError(res: Response): Promise<Object> {
@@ -28,7 +28,18 @@ export function handleHTMLError(res: Response): Promise<Object> {
 }
 
 export function transformToMangaIdsArray(
-  mangaArray: Array<MangaType>
+  mangaArray: Array<Manga>
 ): Array<number> {
   return mangaArray.map(manga => manga.id);
+}
+
+export function withDeletedKeys<K, V>(
+  obj: { [K]: V },
+  keys: Array<K>
+): { [K]: V } {
+  const copy = { ...obj };
+  keys.forEach(key => {
+    delete copy[key];
+  });
+  return copy;
 }

--- a/src/redux-ducks/utils.js
+++ b/src/redux-ducks/utils.js
@@ -33,10 +33,15 @@ export function transformToMangaIdsArray(
   return mangaArray.map(manga => manga.id);
 }
 
+// Support both mutable and read only maps
+type ObjType<K, V> = { [K]: V } | $ReadOnly<{ [K]: V }>;
+
 export function withDeletedKeys<K, V>(
-  obj: { [K]: V },
-  keys: Array<K>
-): { [K]: V } {
+  obj: ObjType<K, V>,
+  keys: ?Array<K>
+): ObjType<K, V> {
+  if (keys == null) return obj;
+
   const copy = { ...obj };
   keys.forEach(key => {
     delete copy[key];

--- a/src/types/index.js
+++ b/src/types/index.js
@@ -1,36 +1,4 @@
 // @flow
-export type MangaInfoFlagsType = {
-  DISPLAY_MODE: "NAME" | "NUMBER",
-  READ_FILTER: "READ" | "UNREAD" | "ALL",
-  SORT_DIRECTION: "ASCENDING" | "DESCENDING",
-  SORT_TYPE: "SOURCE" | "NUMBER",
-  DOWNLOADED_FILTER: "DOWNLOADED" | "NOT_DOWNLOADED" | "ALL"
-};
-
-export type MangaType = {
-  // NOTE: Many non-required fields may be missing because the server needs time to
-  //       scrape the website, but returns a barebones object early anyway.
-
-  // Must be included
-  id: number,
-  favorite: boolean,
-  title: string,
-
-  // I believe these will always be incliuded
-  source: string,
-  url: string,
-  downloaded: boolean,
-  flags: MangaInfoFlagsType,
-
-  chapters: ?number,
-  unread: ?number,
-  author: ?string,
-  description: ?string,
-  thumbnail_url: ?string,
-  genres: ?string,
-  categories: ?Array<string>,
-  status: ?string
-};
 
 export type ChapterType = {
   date: number,
@@ -41,16 +9,6 @@ export type ChapterType = {
   download_status: string,
   id: number,
   last_page_read: number
-};
-
-export type SourceType = {
-  name: string,
-  supports_latest: boolean,
-  id: string,
-  lang: {
-    name: string,
-    display_name: string
-  }
 };
 
 export type LibraryFlagsFiltersType = [

--- a/src/types/index.js
+++ b/src/types/index.js
@@ -1,4 +1,5 @@
 // @flow
+import type { Source } from "@tachiweb/api-client";
 
 export type ChapterType = {
   date: number,
@@ -70,3 +71,5 @@ export type ExtensionType = {
 
 export type PrefValue = string | Array<string> | number | boolean | null | void;
 export type PrefsType = $ReadOnly<{ [key: string]: PrefValue }>;
+
+export type SourceMap = $ReadOnly<{ [id: string]: Source }>;


### PR DESCRIPTION
PR #39 happened right before I did a ton of refactoring. closes #39 

Merging all this code is going to cause some typing inconsistencies, so go back and fix these:

- [x] catalogue actionCreators.js
- [x] selectSources changed its return type. Verify that all uses of it still work
- [x] bug: install extension, go to catalogue, header is not loaded
- [x] setting manga flags does not work, 400 error status. Possibly a server api mismatch.
- [x] ^ inconsistent behavior. Downloaded filter updates on the client side, but read/unread don't

And also
- [x] run through all files to double check for any errors
- [x] run ESLint again just to double check